### PR TITLE
fix: keep playback streams restartable after drain()

### DIFF
--- a/src/client/playback_stream.rs
+++ b/src/client/playback_stream.rs
@@ -136,19 +136,20 @@ impl PlaybackStream {
     }
 
     /// Waits until the given [AudioSource] has reached the end (and returns 0 in [AudioSource::poll_read]),
-    /// and then instructs the server to drain the buffer before ending the stream.
+    /// and then instructs the server to drain the buffer.
     pub async fn play_all(&self) -> ClientResult<()> {
         self.source_eof().await?;
         self.drain().await?;
         Ok(())
     }
 
-    /// Instructs the server to play any remaining data in the buffer, then end
-    /// the stream. This method returns once the stream has finished.
+    /// Instructs the server to play any remaining data in the buffer. This
+    /// method returns once the buffer has been fully played out.
+    ///
+    /// The stream remains connected and usable after the buffer has drained;
+    /// it can be fed more data (e.g. after [PlaybackStream::cork] and
+    /// [PlaybackStream::uncork]) without needing to be recreated.
     pub async fn drain(&self) -> ClientResult<()> {
-        self.0
-            .handle
-            .mark_playback_stream_draining(self.0.info.channel);
         self.0
             .handle
             .roundtrip_ack(protocol::Command::DrainPlaybackStream(self.0.info.channel))

--- a/src/client/reactor.rs
+++ b/src/client/reactor.rs
@@ -27,7 +27,7 @@ struct PlaybackStreamState {
     source: Pin<Box<dyn PlaybackSource>>,
 
     requested_bytes: usize,
-    done: bool,
+    eof: bool,
     eof_notify: Option<oneshot::Sender<()>>,
 }
 
@@ -132,7 +132,7 @@ impl ReactorHandle {
                     source: Box::pin(source),
 
                     requested_bytes,
-                    done: false,
+                    eof: false,
                     eof_notify,
                 },
             );
@@ -166,14 +166,6 @@ impl ReactorHandle {
 
         self.write_command(seq, protocol::Command::DeletePlaybackStream(channel))?;
         rx.await.map_err(|_| ClientError::Disconnected)
-    }
-
-    pub(super) fn mark_playback_stream_draining(&self, channel: u32) {
-        if let Some(state) = self.state.upgrade()
-            && let Some(stream) = state.lock().unwrap().playback_streams.get_mut(&channel)
-        {
-            stream.done = true;
-        }
     }
 
     pub(super) async fn insert_record_stream(
@@ -475,7 +467,7 @@ impl Reactor {
 
         let mut state = self.state.lock().unwrap();
         for stream in state.playback_streams.values_mut() {
-            if stream.done {
+            if stream.eof {
                 continue;
             }
 
@@ -495,8 +487,8 @@ impl Reactor {
                             stream.stream_info.channel
                         );
 
-                        stream.done = true;
-                        stream.eof_notify.take().map(|done| done.send(()));
+                        stream.eof = true;
+                        stream.eof_notify.take().map(|eof| eof.send(()));
                         self.write_buf.clear();
                         break;
                     }


### PR DESCRIPTION
`PlaybackStream::drain()` causes streams to skip writes permanently. This PR fixes that so that drained playback streams can be restarted.